### PR TITLE
Add support for inline task destinations and recipients

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ delegatee.country # => "US"
 | ----------- |--------| --------------|
 | name        | string | The administrator’s complete name. |
 | email       | string | The administrator’s email address. |
-| phone     | string | (Optional) The administrator's E.164-formatted phone number. |
+| phone       | string | (Optional) The administrator's E.164-formatted phone number. |
 
 **Create**
 
@@ -242,8 +242,8 @@ rec = Onfleet::Recipient.find('phone', '4155556789')
 ##Tasks
 | Name        | Type   | Description  |
 | ----------- |--------| --------------|
-| destination     | string | `ID` of the destination. |
-| recipients     | string array | An array containing zero or one IDs of the task's recipients |
+| destination     | string | `ID` of the destination, or the Destination data itself |
+| recipients     | string array | An array containing zero or one IDs of the task's recipients; alternately, an array containing Recipient data as entries |
 | merchant        | string | (Optional) `ID` of merchant organization. |
 | executor       | string | (Optional) `ID` of the executor organization. |
 | complete_after     | number | (Optional)  A timestamp for the earliest time the task should be completed. |
@@ -257,7 +257,23 @@ rec = Onfleet::Recipient.find('phone', '4155556789')
 ```ruby
 # First Create a destination and Recipient
 # Then create the task
-task = Onfleet::Task.create({recipient: ['REC_ID'], destination: 'DEC_ID' })
+task = Onfleet::Task.create({recipients: ['REC_ID'], destination: 'DEC_ID' })
+
+# Alternatively, create the Destination and Recipient in a single call to Onfleet
+# If a recipient exists for the phone number, it will be updated with the new information
+another_task = Onfleet::Task.create(
+  destination: {
+      address: {
+          unparsed: "123 Smith St"
+      },
+      notes: "Some destination notes"
+  },
+  recipients: [{
+      name: "Foo Bar",
+      phone: "987-654-3210",
+      notes: "Some recipient notes"
+  }]
+)
 ```
 
 **Update**

--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ rec = Onfleet::Recipient.find('phone', '4155556789')
 ##Tasks
 | Name        | Type   | Description  |
 | ----------- |--------| --------------|
-| destination     | string | `ID` of the destination, or the Destination data itself |
-| recipients     | string array | An array containing zero or one IDs of the task's recipients; alternately, an array containing Recipient data as entries |
+| destination     | string or hash | `ID` of the destination, or the Destination data itself |
+| recipients     | array of string or hash | An array containing zero or one IDs of the task's recipients; alternately, an array containing Recipient data as entries |
 | merchant        | string | (Optional) `ID` of merchant organization. |
 | executor       | string | (Optional) `ID` of the executor organization. |
 | complete_after     | number | (Optional)  A timestamp for the earliest time the task should be completed. |

--- a/lib/onfleet-ruby.rb
+++ b/lib/onfleet-ruby.rb
@@ -21,7 +21,6 @@ require 'onfleet-ruby/actions/get'
 require 'onfleet-ruby/actions/list'
 require 'onfleet-ruby/actions/delete'
 
-
 # Resources
 require 'onfleet-ruby/onfleet_object'
 require 'onfleet-ruby/recipient'

--- a/lib/onfleet-ruby/onfleet_object.rb
+++ b/lib/onfleet-ruby/onfleet_object.rb
@@ -57,7 +57,7 @@ module Onfleet
 
       def parse_onfleet_obj obj
         if obj.is_a?(OnfleetObject)
-          if obj.is_a?(Destination) || obj.is_a?(Recipient) || obj.is_a?(Task)
+          if obj.respond_to?('id') && obj.id && (obj.is_a?(Destination) || obj.is_a?(Recipient) || obj.is_a?(Task))
              obj.id
           else
             obj.attributes

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
-require 'onfleet'
-require File.expand_path('./test_data', __FILE__)
+require 'onfleet-ruby'
+require File.expand_path('../test_data', __FILE__)


### PR DESCRIPTION
Add support for creating the Destination and Recipient in a single call to Onfleet::Task.create

For example (from README.md):
```
Onfleet::Task.create(
  destination: {
      address: {
          unparsed: "123 Smith St"
      },
      notes: "Some destination notes"
  },
  recipients: [{
      name: "Foo Bar",
      phone: "987-654-3210",
      notes: "Some recipient notes"
  }]
)
```