### PR TITLE
Add metadata query support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ delegatee.country # => "US"
 | name        | string | The administrator’s complete name. |
 | email       | string | The administrator’s email address. |
 | phone     | string | (Optional) The administrator's E.164-formatted phone number. |
+| metadata  | array  | (Optional) Any associated metadata |
 
 **Create**
 
@@ -95,7 +96,8 @@ Worker
 | name        | string | The workers complete name. |
 | phone       | string | The worker's phone number. |
 | teams     | string Array | One or more team IDs of which the worker is a member.|
-| vehicle     | obect | (Optional) The worker’s vehicle, providing no vehicle details is interpreted as the worker being on foot. |
+| vehicle     | object | (Optional) The worker’s vehicle, providing no vehicle details is interpreted as the worker being on foot. |
+| metadata    | array  | (Optional) Any associated metadata |
 
 Vehicle
 
@@ -164,6 +166,7 @@ Destination
 | address        | object | The destination’s street address details. |
 | location       | array | (Optional) The `[ longitude, latitude ]` geographic coordinates. If missing, the API will geocode based on the `address` details provided. Note that geocoding may slightly modify the format of the address properties. |
 | notes     | string | (Optional) Notes for the destination |
+| metadata  | array  | (Optional) Any associated metadata |
 
 Address
 
@@ -178,7 +181,6 @@ Address
 | state     | string |  (Optional) State name |
 | postal_code     | string | (Optional) The postal code |
 | unparsed     | string | (Optional) A complete comma seperated address for ex. `148 townsend, 94102, USA`. Including this field, all other address details will be ignored. The address will be automatically geocoded. |
-
 
 
 
@@ -204,6 +206,7 @@ Onfleet::Destination('DEST_ID')
 | notes     | string | (Optional) Notes for the recipient. |
 | skip_sms_notifications     | boolean | (Optional) To disable sms notification. Defaults to `false` |
 | skip_phone_number_verificaton     | boolean | (Optional) Whether to skip validation of the phone number. |
+| metadata  | array  | (Optional) Any associated metadata |
 
 **Create**
 ```ruby
@@ -239,7 +242,7 @@ rec.name = "John Doe"
 rec = Onfleet::Recipient.find('phone', '4155556789')
 ```
 
-##Tasks
+## Tasks
 | Name        | Type   | Description  |
 | ----------- |--------| --------------|
 | destination     | string | `ID` of the destination. |
@@ -252,6 +255,7 @@ rec = Onfleet::Recipient.find('phone', '4155556789')
 | dependencies     | string array | (Optional) One or more IDs of tasks which must be completed prior to this task. |
 | notes     | notes | (Optional) Notes for the task. |
 | auto_assign     | object | (Optional) The automatic assignment options for the newly created task. See above for exact object structure and allowed values. |
+| metadata  | array  | (Optional) Any associated metadata |
 
 **Create**
 ```ruby
@@ -286,6 +290,15 @@ Onfleet::Task.list({state: 0}) # => returns all tasks with state 0, see official
 
 **Complete**
 Currently not supported
+
+
+## Metadata
+| Name        | Type   | Description  |
+| ----------- |--------| --------------|
+| name     | string | the name of the property |
+| type     | string | The type of the property. Must be one of [ ‘boolean’, ‘number’, ‘string’, ‘object’, ‘array’ ] |
+| subtype  | string | (Optional) Required only for entries of type array, used for future visualization purposes. Must be one of [ ‘boolean’, ‘number’, ‘string’, ‘object’ ]. |
+| value    | string | The value of the property. The JSON type must match the type (and subtype) provided for the entry. |
 
 
 ##Error Handling

--- a/README.md
+++ b/README.md
@@ -300,8 +300,13 @@ Currently not supported
 | subtype  | string | (Optional) Required only for entries of type array, used for future visualization purposes. Must be one of [ ‘boolean’, ‘number’, ‘string’, ‘object’ ]. |
 | value    | string | The value of the property. The JSON type must match the type (and subtype) provided for the entry. |
 
+```ruby
+# Returns an array with entities matching the metadata query
+# Any entity supporting metadata can be queried (eg: Admins, Workers, Tasks, Destinations, Recipients)
+tasks = Onfleet::Task.query_by_metadata([{name: "property", type: "string", value: "abc"}])
+```
 
-##Error Handling
+## Error Handling
 ```ruby
 begin
   # perform onfleet api requests

--- a/lib/onfleet-ruby.rb
+++ b/lib/onfleet-ruby.rb
@@ -20,7 +20,7 @@ require 'onfleet-ruby/actions/update'
 require 'onfleet-ruby/actions/get'
 require 'onfleet-ruby/actions/list'
 require 'onfleet-ruby/actions/delete'
-
+require 'onfleet-ruby/actions/query_metadata'
 
 # Resources
 require 'onfleet-ruby/onfleet_object'

--- a/lib/onfleet-ruby/actions/query_metadata.rb
+++ b/lib/onfleet-ruby/actions/query_metadata.rb
@@ -1,0 +1,17 @@
+module Onfleet
+  module Actions
+    module QueryMetadata
+      module ClassMethods
+        def query_by_metadata metadata
+          api_url = "#{self.api_url}/metadata"
+          response = Onfleet.request(api_url, :post, metadata)
+          response.map { |item| Util.constantize("#{self}").new(item) } if response.is_a? Array
+        end
+      end
+
+      def self.included base
+        base.extend(ClassMethods)
+      end
+    end
+  end
+end

--- a/lib/onfleet-ruby/admin.rb
+++ b/lib/onfleet-ruby/admin.rb
@@ -5,7 +5,7 @@ module Onfleet
     include Onfleet::Actions::Update
     include Onfleet::Actions::List
     include Onfleet::Actions::Delete
-
+    include Onfleet::Actions::QueryMetadata
 
     def self.api_url
       '/admins'

--- a/lib/onfleet-ruby/destination.rb
+++ b/lib/onfleet-ruby/destination.rb
@@ -3,7 +3,7 @@ module Onfleet
     include Onfleet::Actions::Create
     include Onfleet::Actions::Save
     include Onfleet::Actions::Get
-
+    include Onfleet::Actions::QueryMetadata
 
     def self.api_url
       '/destinations'

--- a/lib/onfleet-ruby/recipient.rb
+++ b/lib/onfleet-ruby/recipient.rb
@@ -5,6 +5,7 @@ module Onfleet
     include Onfleet::Actions::Save
     include Onfleet::Actions::Find
     include Onfleet::Actions::Get
+    include Onfleet::Actions::QueryMetadata
 
     def self.api_url
       "/recipients"

--- a/lib/onfleet-ruby/task.rb
+++ b/lib/onfleet-ruby/task.rb
@@ -6,7 +6,7 @@ module Onfleet
     include Onfleet::Actions::Get
     include Onfleet::Actions::List
     include Onfleet::Actions::Delete
-
+    include Onfleet::Actions::QueryMetadata
 
     def self.api_url
       '/tasks'

--- a/lib/onfleet-ruby/worker.rb
+++ b/lib/onfleet-ruby/worker.rb
@@ -6,7 +6,7 @@ module Onfleet
     include Onfleet::Actions::Save
     include Onfleet::Actions::Update
     include Onfleet::Actions::Delete
-
+    include Onfleet::Actions::QueryMetadata
 
     def self.api_url
       '/workers'


### PR DESCRIPTION
Add metadata query support (see http://docs.onfleet.com/docs/metadata)

Example:
`tasks = Onfleet::Task.query_by_metadata([{name: "property", type: "string", value: "abc"}])`