### PR TITLE
Excludes params from attributes hash

### DIFF
--- a/lib/onfleet-ruby/onfleet_object.rb
+++ b/lib/onfleet-ruby/onfleet_object.rb
@@ -21,9 +21,9 @@ module Onfleet
 
     def attributes
       attrs = Hash.new
-      instance_variables.each do |var|
+      instance_variables.select {|var| var != '@params'}.each do |var|
         str = var.to_s.gsub /^@/, ''
-        if respond_to? "#{str}="
+        if respond_to?("#{str}=")
           instance_var = instance_variable_get(var)
           if klass = Util.object_classes[str]
             if instance_var.is_a?(OnfleetObject)


### PR DESCRIPTION
Removes `@params` from the list of variables to use in creating the attributes hash, preventing it from ending up in the JSON serialization of the Onfleet object when it's saved/POSTed to Onfleet's API.

It looks like occasionally the `set_attributes` method is called with a `params` value that contains a `params` key. This causes an accessor to be created for `@params` (within `add_attrs`). `@params` then passes the `respond_to?` test within the instance variables loop of `attributes`, causing `params` to be included in the hash created by attributes. Finally, that is sent along to Onfleet, were the extra `params` attribute violates their strict validation and causes a failure.

In practice, it looks something like this. A otherwise perfectly fine Onfleet::Destination object:

```
 <Onfleet::Destination:0x007ff4eaf32e10 @params={:address=>{:number=>"3733",
 :street=>"N Southport Ave", :city=>"Chicago", :postal_code=>"60613",
 :state=>"IL", :country=>"USA"}, :location=>[-87.6638617, 41.9498668],
 :metadata=>[{:name=>"environment", :type=>"string", :value=>"cc-dev"},
 {:name=>"location_id", :type=>"number", :value=>80}]},
 @address=#<Onfleet::Address:0x007ff4eaf324d8 @params={:number=>"3733",
 :street=>"N Southport Ave", :city=>"Chicago", :postal_code=>"60613",
 :state=>"IL", :country=>"USA"}, @number="3733", @street="N Southport Ave",
 @city="Chicago", @postal_code="60613", @state="IL", @country="USA">,
 @location=[-87.6638617, 41.9498668], @metadata=[{:name=>"environment",
 :type=>"string", :value=>"cc-dev"}, {:name=>"location_id", :type=>"number",
 :value=>80}]>
```

That object has an accessor for the `@param` instance var, so it ends up generating this hash from the `attributes` method:

```
{:params=>{:address=>{:number=>"3733", :street=>"N Southport Ave",
:city=>"Chicago", :postal_code=>"60613", :state=>"IL", :country=>"USA"},
:location=>[-87.6638617, 41.9498668], :metadata=>[{:name=>"environment",
:type=>"string", :value=>"cc-dev"}, {:name=>"location_id", :type=>"number",
:value=>80}]}, :address=>{:params=>{:number=>"3733", :street=>"N Southport Ave",
:city=>"Chicago", :postal_code=>"60613", :state=>"IL", :country=>"USA"},
:number=>"3733", :street=>"N Southport Ave", :city=>"Chicago",
:postalCode=>"60613", :state=>"IL", :country=>"USA"}, :location=>[-87.6638617,
41.9498668], :metadata=>[{:name=>"environment", :type=>"string",
:value=>"cc-dev"}, {:name=>"location_id", :type=>"number", :value=>80}]}
```

Which, when sent along to Onfleet, then causes an error that looks something like this:

```
<Onfleet::OnfleetError: {"error"=>1900, "message"=>"One or more parameters
required for this request are either missing or have an invalid format.",
"request"=>"f6db2713-6e33-4191-ac43-15ff9808ecda", "cause"=>"Improper address
provided: params is not allowed"}>
```
