### PR TITLE
Bugfix: Task list with filter

### DIFF
--- a/lib/onfleet-ruby/actions/list.rb
+++ b/lib/onfleet-ruby/actions/list.rb
@@ -6,7 +6,7 @@ module Onfleet
           api_url = "#{self.api_url}"
 
           if !query_params.empty?
-            api_url += "?"
+            api_url += "/all?"
             query_params.each do |key, value|
               api_url += "#{key}=#{value}&"
             end


### PR DESCRIPTION
The path for tasks is `/tasks`
With query params, we need concat `all`, so the path is `/tasks/all?from=...`