### PR TITLE
Update onfleet-ruby.gemspec 

### DIFF
--- a/onfleet-ruby.gemspec
+++ b/onfleet-ruby.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.add_dependency('activesupport', '>= 4.2')
-  s.add_dependency('rest-client', '~> 1.4')
+  s.add_dependency('rest-client', '>= 2.0')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', '~> 3.3')


### PR DESCRIPTION
to solve the following error

KeyError: key not found: :ciphers
from  ~/.rvm/gems/ruby-2.6.0/gems/rest-client-1.8.0/lib/restclient/request.rb:163:in `fetch'